### PR TITLE
Use “command” command to execute “rm”

### DIFF
--- a/nvm.fish
+++ b/nvm.fish
@@ -97,6 +97,6 @@ function nvm
     set s $status
   end
 
-  rm -r $tmpdir
+  command rm -r $tmpdir
   return $s
 end


### PR DESCRIPTION
If a user happens to have a fish function named `rm` that wraps the native `rm` it will cause problems. Using `command` bypasses fish functions.
